### PR TITLE
FEAT: Added Rho

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.rust == 'nightly' 
       env:
         CARGO_INCREMENTAL: 0
-        RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+        RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
         CRATE_NAME: black_scholes
       run: |
         cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push]
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,9 +28,10 @@ jobs:
       if: matrix.rust == 'nightly' 
       env:
         CARGO_INCREMENTAL: 0
-        RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
+        RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests
         CRATE_NAME: black_scholes
       run: |
+        cargo clean
         cargo test
         curl -L https://github.com/mozilla/grcov/releases/download/v0.5.5/grcov-linux-x86_64.tar.bz2 | tar jxf -
         zip -0 ccov.zip `find . \( -name "${CRATE_NAME}*.gc*" \) -print`


### PR DESCRIPTION
This adds Rho for call & put options. Also added greeks tests for a sample option.

On my machine the test `call_iv_works_with_broad_set_of_numbers` fails with 
```
thread 'tests::call_iv_works_with_broad_set_of_numbers' panicked at 'called `Result::unwrap()` on an `Err` value: NaN', src/lib.rs:532:85
```
